### PR TITLE
Add Content-Security-Policy header for docs.gateway.fm RD-684

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -92,6 +92,26 @@ const config: Config = {
     ]
   ],
   themes: ["docusaurus-theme-openapi-docs"],
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        'http-equiv': 'Content-Security-Policy',
+        content: [
+          "default-src 'self'",
+          "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+          "style-src 'self' 'unsafe-inline'",
+          "img-src 'self' data: https:",
+          "font-src 'self' data:",
+          "connect-src 'self' https:",
+          "frame-ancestors 'none'",
+          "base-uri 'self'",
+          "form-action 'self'",
+        ].join('; '),
+      },
+    },
+  ],
+
   themeConfig: {
     image: 'img/logo.svg',
     navbar: {


### PR DESCRIPTION
## Summary
- Adds a Content-Security-Policy (CSP) meta tag via Docusaurus `headTags` config to resolve the Aikido security finding
- Since GitHub Pages doesn't support custom HTTP response headers, the CSP is delivered as a `<meta http-equiv>` tag injected into every page
- Policy restricts resource loading to same-origin with necessary exceptions for Docusaurus inline scripts/styles and HTTPS connections for the API explorer

## CSP Directives
| Directive | Value | Reason |
|---|---|---|
| `default-src` | `'self'` | Same-origin default |
| `script-src` | `'self' 'unsafe-inline' 'unsafe-eval'` | Docusaurus + inline script injection in Root.js |
| `style-src` | `'self' 'unsafe-inline'` | Docusaurus inline styles |
| `img-src` | `'self' data: https:` | Local images, data URIs, external images |
| `font-src` | `'self' data:` | Local/embedded fonts |
| `connect-src` | `'self' https:` | API explorer RPC calls to external endpoints |
| `frame-ancestors` | `'none'` | Clickjacking protection |
| `base-uri` | `'self'` | Prevent base tag injection |
| `form-action` | `'self'` | Restrict form submissions |

## Test plan
- [x] `docusaurus build` succeeds
- [x] CSP meta tag present in built HTML output
- [ ] Verify site loads correctly after deploy with no console CSP violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)